### PR TITLE
Assorted Fixes and Improvements

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,13 +2,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-# This is so we know where to get delivery-truck's dependency
-cookbook 'delivery-sugar',
-         git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
-         branch: 'master'
-
-group :delivery do
-  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
-  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
-  cookbook 'test', path: './test/fixtures/cookbooks/test'
-end
+cookbook 'delivery-truck'
+cookbook 'delivery-sugar', git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
+cookbook 'test', path: './test/fixtures/cookbooks/test'

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ depends 'delivery-truck'
 Add to your build cookbook's Berksfile:
 
 ```ruby
-cookbook 'delivery-sugar',
-         git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
-         branch: 'master'
+source "https://supermarket.chef.io"
 
-group :delivery do
-  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
-  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
-  cookbook 'delivery-truck', git: 'https://github.com/chef-cookbooks/delivery-truck'
-  cookbook 'habitat-build', git: 'git@github.com:habitat-sh/habitat-build-cookbook'
-end
+metadata
+
+cookbook 'delivery-truck'
+
+cookbook 'delivery-base',  git: 'https://github.com/chef-cookbooks/delivery-base.git'
+cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build.git'
+cookbook 'delivery-sugar', git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
+cookbook 'habitat-build',  git: 'https://github.com/chef-cookbooks/habitat-build.git'
 ```
 
 Include `habitat-build` recipes in your build cookbook's phase

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Cookbook recipe helper methods.
 
 `habitat_plan_dir`: returns the directory where the plan lives. Searches the `delivery/config.json` of the build cookbook configuration, followed by an attribute, and falls back to `/src/habitat`.
 
-`habitat_secrets?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `keyname`, `private_key`, and `public_key`.
+`habitat_secrets?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `keyname`, `private_key`, `public_key`, and `depot_token`.
 
 ## License and Author
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Cookbook recipe helper methods.
 
 `habitat_plan_dir`: returns the directory where the plan lives. Searches the `delivery/config.json` of the build cookbook configuration, followed by an attribute, and falls back to `/src/habitat`.
 
-`habitat_secrets?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `keyname`, `private_key`, `public_key`, and `depot_token`.
+`habitat_origin_key?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `keyname`, `private_key`, `public_key`.
+
+`habitat_depot_token?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `depot_token`.
 
 ## License and Author
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ source "https://supermarket.chef.io"
 metadata
 
 cookbook 'delivery-truck'
-
-cookbook 'delivery-base',  git: 'https://github.com/chef-cookbooks/delivery-base.git'
-cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build.git'
 cookbook 'delivery-sugar', git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
 cookbook 'habitat-build',  git: 'https://github.com/chef-cookbooks/habitat-build.git'
 ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,7 +47,7 @@ def habitat_secrets?
   end
 
   return false unless key_data.key?('habitat') && !key_data['habitat'].empty?
-  %w(keyname private_key public_key).each do |req_key|
+  %w(keyname private_key public_key depot_token).each do |req_key|
     if key_data['habitat'].key?(req_key) && !key_data['habitat'][req_key].empty?
       next
     else

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -57,3 +57,28 @@ def habitat_secrets?
 
   true
 end
+
+def hab_binary
+  File.join('/hab/pkgs', node['habitat-build']['hab-pkgident'], 'bin/hab')
+end
+
+def hab_studio_binary
+  File.join('/hab/pkgs', node['habitat-build']['hab-studio-pkgident'], 'bin/hab-studio')
+end
+
+# For example, if the project is `surprise-sandwich`, and we're in the
+# Build stage's Publish phase, the slug will be:
+#
+#    `surprise-sandwich-build-publish`
+#
+def hab_studio_slug
+  [
+    node['delivery']['change']['project'],
+    node['delivery']['change']['stage'],
+    node['delivery']['change']['phase']
+  ].join('-')
+end
+
+def hab_studio_path
+  File.join('/hab/studios', hab_studio_slug)
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'apache2'
 version '0.7.0'
 
 depends 'delivery-sugar'
-depends 'delivery_build'
+depends 'delivery-truck'
 
 gem 'habitat-client'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,7 +55,7 @@ end
 # `hab studio` command as root because it requires privileged access
 # to bind mount the project directory in the studio.
 file '/etc/sudoers.d/dbuild-hab-studio' do
-  content "dbuild ALL=(ALL) NOPASSWD: /hab/pkgs/#{hab_studio_pkgident}/bin/hab studio\n"
+  content "dbuild ALL=(ALL) NOPASSWD: /hab/pkgs/#{hab_studio_pkgident}/bin/hab-studio\n"
 end
 
 # Before we get started, clean up from a previous build

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -125,19 +125,3 @@ file 'source-public-key' do
   owner 'dbuild'
   mode '0600'
 end
-
-file 'studio-private-key' do
-  path lazy { "/hab/studios/#{studio_slug}/hab/cache/keys/#{keyname}.sig.key" }
-  content lazy { IO.read("/hab/cache/keys/#{keyname}.sig.key") }
-  sensitive true
-  owner 'dbuild'
-  mode '0600'
-end
-
-file 'origin-public-key' do
-  path lazy { "/hab/studios/#{studio_slug}/hab/cache/keys/#{keyname}.pub" }
-  content lazy { IO.read("/hab/cache/keys/#{keyname}.pub") }
-  sensitive true
-  owner 'dbuild'
-  mode '0600'
-end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,24 +58,6 @@ file '/etc/sudoers.d/dbuild-hab-studio' do
   content "dbuild ALL=(ALL) NOPASSWD: /hab/pkgs/#{hab_studio_pkgident}/bin/hab-studio\n"
 end
 
-# Before we get started, clean up from a previous build
-execute "remove-studio #{studio_slug}" do
-  command "hab studio -r /hab/studios/#{studio_slug} rm"
-  cwd node['delivery']['workspace']['repo']
-  ignore_failure true
-end
-
-# Create the new studio. These are lightweight until an artifact is
-# actually built.
-execute "create-studio #{studio_slug}" do
-  command "hab studio -r /hab/studios/#{studio_slug} new"
-  cwd node['delivery']['workspace']['repo']
-end
-
-directory "/hab/studios/#{studio_slug}/hab/cache/keys" do
-  recursive true
-end
-
 # Attempt to load the origin key from `delivery-secrets` data bag item
 # named for this project. If it doesn't exist, we'll generate our own
 # key. Some of these variables are not available until these resources

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,7 +49,7 @@ keyname = nil
 private_key = nil
 public_key = nil
 
-if habitat_secrets?
+if habitat_origin_key?
   load_delivery_chef_config
   key_data = get_project_secrets
   private_key = key_data['habitat']['private_key']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -99,9 +99,9 @@ else
       command << ' origin key generate'
       command << ' delivery'
       key_gen = shell_out(command)
-      keyname = key_gen.stdout.gsub(/\e\[(\d+)m/, '').chomp.split.last
-      private_key = IO.read("/hab/cache/keys/#{keyname}sig.key")
-      public_key = IO.read("/hab/cache/keys/#{keyname}pub")
+      keyname = key_gen.stdout.gsub(/\e\[(\d+)m/, '').chomp.split.last.chop
+      private_key = IO.read("/hab/cache/keys/#{keyname}.sig.key")
+      public_key = IO.read("/hab/cache/keys/#{keyname}.pub")
     end
   end
 end
@@ -111,7 +111,7 @@ end
 # latter is fine because Chef is convergent and won't change the file
 # if it doesn't need to.
 file 'source-private-key' do
-  path lazy { "/hab/cache/keys/#{keyname}sig.key" }
+  path lazy { "/hab/cache/keys/#{keyname}.sig.key" }
   content lazy { private_key }
   sensitive true
   owner 'dbuild'
@@ -119,7 +119,7 @@ file 'source-private-key' do
 end
 
 file 'source-public-key' do
-  path lazy { "/hab/cache/keys/#{keyname}pub" }
+  path lazy { "/hab/cache/keys/#{keyname}.pub" }
   content lazy { public_key }
   sensitive true
   owner 'dbuild'
@@ -127,16 +127,16 @@ file 'source-public-key' do
 end
 
 file 'studio-private-key' do
-  path lazy { "/hab/studios/#{studio_slug}/hab/cache/keys/#{keyname}sig.key" }
-  content lazy { IO.read("/hab/cache/keys/#{keyname}sig.key") }
+  path lazy { "/hab/studios/#{studio_slug}/hab/cache/keys/#{keyname}.sig.key" }
+  content lazy { IO.read("/hab/cache/keys/#{keyname}.sig.key") }
   sensitive true
   owner 'dbuild'
   mode '0600'
 end
 
 file 'origin-public-key' do
-  path lazy { "/hab/studios/#{studio_slug}/hab/cache/keys/#{keyname}pub" }
-  content lazy { IO.read("/hab/cache/keys/#{keyname}pub") }
+  path lazy { "/hab/studios/#{studio_slug}/hab/cache/keys/#{keyname}.pub" }
+  content lazy { IO.read("/hab/cache/keys/#{keyname}.pub") }
   sensitive true
   owner 'dbuild'
   mode '0600'

--- a/recipes/provision.rb
+++ b/recipes/provision.rb
@@ -21,9 +21,10 @@
 # Take advantage of delivery-truck's built in version pinning and promotion
 include 'delivery-truck::provision'
 
-ruby_block 'promote-artifact' do
-  block do
-    hc = Habitat::Client.new
-    hc.promote_package(artifact_data['artifact']['pkg_ident'], node['delivery']['change']['stage'])
-  end
-end
+# TODO: re-enable this when `Habitat::Client` supports Depots that require authn
+# ruby_block 'promote-artifact' do
+#   block do
+#     hc = Habitat::Client.new
+#     hc.promote_package(artifact_data['artifact']['pkg_ident'], node['delivery']['change']['stage'])
+#   end
+# end

--- a/recipes/provision.rb
+++ b/recipes/provision.rb
@@ -18,17 +18,8 @@
 # limitations under the License.
 #
 
-artifact_data = {}
-ruby_block 'lookup-artifact-data' do
-  block do
-    load_delivery_chef_config
-    artifact_data = search(project_slug, # ~FC003
-                           "change_id:#{delivery_change_id}").first
-    if artifact_data.empty? || !artifact_data['artifact']['pkg_ident']
-      raise 'Could not load artifact data!'
-    end
-  end
-end
+# Take advantage of delivery-truck's built in version pinning and promotion
+include 'delivery-truck::provision'
 
 ruby_block 'promote-artifact' do
   block do

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -40,6 +40,7 @@ build #{habitat_plan_dir}
     'TERM' => 'ansi'
   )
   cwd node['delivery']['workspace']['repo']
+  live_stream true
 end
 
 ruby_block 'load-build-output' do
@@ -62,6 +63,7 @@ end
 
 execute 'upload-pkg' do
   command lazy { "#{hab_binary} pkg upload --url #{node['habitat-build']['depot-url']} --auth '#{depot_token}' #{::File.join(hab_studio_path, '/src/results', artifact)}" }
+  live_stream true
 end
 
 # update a data bag with the artifact build info

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -69,16 +69,16 @@ ruby_block 'build-plan' do
   end
 end
 
-ruby_block 'artifact-hash' do
+ruby_block 'generate-pkg-hash' do
   block do
     command = "/hab/pkgs/#{hab_pkgident}/bin/hab"
-    command << " artifact hash #{::File.join(studio_path, '/src/results', artifact)}"
+    command << " pkg hash #{::File.join(studio_path, '/src/results', artifact)}"
     artifact_hash = shell_out(command).stdout.chomp
   end
 end
 
-execute 'upload-artifact' do
-  command lazy { "#{::File.join('/hab/pkgs', hab_pkgident, 'bin/hab')} artifact upload --url #{node['habitat-build']['depot-url']} --auth '#{depot_token}' #{::File.join(studio_path, '/src/results', artifact)}" }
+execute 'upload-pkg' do
+  command lazy { "#{::File.join('/hab/pkgs', hab_pkgident, 'bin/hab')} pkg upload --url #{node['habitat-build']['depot-url']} --auth '#{depot_token}' #{::File.join(studio_path, '/src/results', artifact)}" }
 end
 
 # update a data bag with the artifact build info

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -71,8 +71,11 @@ ruby_block 'artifact-hash' do
   end
 end
 
+project_secrets = get_project_secrets
+depot_token = project_secrets['habitat']['depot_token']
+
 execute 'upload-artifact' do
-  command lazy { "#{::File.join('/hab/pkgs', hab_pkgident, 'bin/hab')} artifact upload #{::File.join(studio_path, '/src/results', artifact)}" }
+  command lazy { "#{::File.join('/hab/pkgs', hab_pkgident, 'bin/hab')} artifact upload --url #{node['habitat-build']['depot-url']} --auth '#{depot_token}' #{::File.join(studio_path, '/src/results', artifact)}" }
 end
 
 # update a data bag with the artifact build info


### PR DESCRIPTION
Highlights include:

* Produce delivery-truck style data bag items and environment data, we'll also take advantage of delivery-truck's built in environment promotion logic. Example output data can be seen here:
https://gist.github.com/schisamo/a9f04c1fbfdcdb6367a05de03bc3e56d
* Pass the origin key at build time since the studio is rebuilt from scratch every build
* Don't remove/create studio in default recipe as `hab-studio build` does this for us.
* Properly upload to depots that require auth (like willem).
* `hab artifact` commands are now namespaced at `hab pkg`
* Use live stream for real time output on build and upload commands.
* Add some helpers and dry things up

The following habitat artifact was built and uploaded using these updates and delivery.chef.co!
https://app.habitat.sh/#/pkgs/chef-es/package-router/0.1.0/20160625155928
https://delivery.chef.co/e/chef/#/organizations/engineering-services/projects/es-package-router/changes/04eaa0b8-5206-45a1-934e-4d7c78696d08/status/build

/cc @chef-cookbooks/engineering-services @chef-cookbooks/habitat-team @chef-cookbooks/chef-operations @chef-cookbooks/cia @chef-cookbooks/delivery 