### PR TITLE
Lint and syntax check all plan.sh's

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.10.1'
+version '0.10.2'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/recipes/lint.rb
+++ b/recipes/lint.rb
@@ -21,6 +21,6 @@
 execute 'lint-check-plan' do
   # by targetting bash, we avoid warning on SC2148
   # https://github.com/koalaman/shellcheck/wiki/SC2148
-  command "shellcheck -e #{node['habitat-build']['shellcheck-excludes'].join(',')} -s bash habitat/plan.sh"
+  command "find . -name 'plan.sh' -exec shellcheck -e #{node['habitat-build']['shellcheck-excludes'].join(',')} -s bash {} \;"
   cwd node['delivery']['workspace']['repo']
 end

--- a/recipes/syntax.rb
+++ b/recipes/syntax.rb
@@ -19,6 +19,6 @@
 #
 
 execute 'syntax-check-plan' do
-  command 'bash -n habitat/plan.sh'
+  command 'find . -name "plan.sh" -exec bash -n {} \;'
   cwd node['delivery']['workspace']['repo']
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

This commit changes the lint and syntax recipes to find all `plan.sh`
files in the repository workspace and check them. This is to support
repositories that have multiple habitat packages.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/03b7c668-d33f-4cac-8cd2-78fb7a0a5372