### PR TITLE
Refactor the artifact data bag/env tracking

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.10.2'
+version '0.10.3'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -50,45 +50,23 @@ if changed_habitat_files?
   #########################################################################
 
   # update a data bag with the artifact build info
-  # TODO: (jtimberman) This is not the first time this has been used in
-  # a delivery build cookbook. It's probably time to create a Chef
-  # resource for this functionality
-  ruby_block 'track-artifact-data' do # ~FC014
-    block do
-      load_delivery_chef_config
-      proj = Chef::DataBag.new
-      proj.name(project_name)
-      proj.save
+  load_delivery_chef_config
+  chef_data_bag project_name
 
-      proj_data = {
+  chef_data_bag_item build_version do
+    raw_data lazy do
+      {
         'id' => build_version,
         'version' => build_version,
         'artifact' => last_build_env.merge('type' => 'hart'),
         'delivery_data' => node['delivery'],
       }
-
-      proj_item = Chef::DataBagItem.new
-      proj_item.data_bag(proj.name)
-      proj_item.raw_data = proj_data
-      proj_item.save
     end
   end
 
-  ruby_block 'set-build-version-in-environment' do
-    block do
-      load_delivery_chef_config
-      begin
-        to_env = Chef::Environment.load(get_acceptance_environment)
-      rescue Net::HTTPServerException => http_e
-        raise http_e unless http_e.response.code.to_i == 404
-        to_env = Chef::Environment.new
-        to_env.name(get_acceptance_environment)
-        to_env.create
-      end
-
-      to_env.override_attributes['applications'] ||= {}
-      to_env.override_attributes['applications'][project_name] = build_version
-      to_env.save
+  chef_environment get_acceptance_environment do
+    override_attributes lazy do
+      { project_name => build_version }
     end
   end
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

The ruby blocks used in the publish recipe were cargo-culted from
other projects. We don't need to make our own custom resource to
simplify these, we can use the existing "chef_data_bag_item" and
"chef_environment" resources that are provided by the cheffish library
(a dependency of chef).

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/94ee9f1a-d0bb-4dcc-b925-67b8bd1f2e6b