### PR TITLE
Disable spinner for hab_build resource calls

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.10.6'
+version '0.10.7'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -20,7 +20,9 @@ action :build do
     command "sudo -E #{hab_binary} studio" \
             " -r #{hab_studio_path}" \
             " build #{plan_dir}"
-    environment('TERM' => 'vt100', 'HAB_ORIGIN' => origin)
+    environment('TERM' => 'vt100',
+                'HAB_ORIGIN' => origin,
+                'HAB_NONINTERACTIVE' => 'true')
     cwd new_resource.cwd
     live_stream new_resource.live_stream
   end
@@ -30,7 +32,8 @@ action :publish do
   execute 'upload-pkg' do
     command lazy { "#{hab_binary} pkg upload --url #{url} #{hab_studio_path}/src/results/#{artifact}" }
     env('HOME' => home_dir,
-        'HAB_AUTH_TOKEN' => auth_token)
+        'HAB_AUTH_TOKEN' => auth_token,
+        'HAB_NONINTERACTIVE' => 'true')
     live_stream new_resource.live_stream
     sensitive true
   end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Elliott Davis



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/202f00f6-07d4-479f-8606-84b6413bf4f3