### PR TITLE
Don't overwrite existing acceptance environment

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,6 +26,14 @@
 #   }
 # }
 
+# The current acceptance environment on the server
+def existing_acceptance_environment
+  Chef::ServerAPI.new.get("environments/#{get_acceptance_environment}")
+rescue Net::HTTPServerException => e
+  raise e unless e.response.code.to_i == 404
+  {}
+end
+
 def habitat_plan_dir
   if node['delivery']['config'].attribute?('habitat') &&
      node['delivery']['config']['habitat'].attribute?('plan_dir')

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -62,7 +62,9 @@ action :publish do
 
   chef_environment get_acceptance_environment do
     override_attributes lazy {
-      { new_resource.name => build_version }
+      existing_acceptance_environment.fetch("override_attributes", {}).merge({
+        new_resource.name => build_version
+      })
     }
   end
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Nathan Smith

When setting the environment attributes, fetch the existing environment
first, so you don't wipe out all of the existing override_attributes.

Fixes #15

Signed-off-by: Nathan L Smith <smith@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/fa0f235f-a4c0-4cff-9136-50126091b9e0