### PR TITLE
Update cookbook to properly use Automate's Project Application pattern 

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -25,15 +25,6 @@
 #     "plan_dir": "/elsewhere/plans/myplan"
 #   }
 # }
-
-# The current acceptance environment on the server
-def existing_acceptance_environment
-  Chef::ServerAPI.new.get("environments/#{get_acceptance_environment}")
-rescue Net::HTTPServerException => e
-  raise e unless e.response.code.to_i == 404
-  {}
-end
-
 def habitat_plan_dir
   if node['delivery']['config'].attribute?('habitat') &&
      node['delivery']['config']['habitat'].attribute?('plan_dir')

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -104,5 +104,5 @@ def artifact
 end
 
 def build_version
-  [last_build_env['pkg_version'], last_build_env['pkg_release']].join('-')
+  [last_build_env['pkg_version'], last_build_env['pkg_release']].join('/')
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -14,95 +14,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Get the plan directory from the config, or fallback to /src, set
-# this in .delivery/config.json.
-#
-# Examples:
-# {
-#   ...
-#   "habitat": {
-#     "plan_dir": "/src/plans"
-#     "plan_dir": "/elsewhere/plans/myplan"
-#   }
-# }
-def habitat_plan_dir
-  if node['delivery']['config'].attribute?('habitat') &&
-     node['delivery']['config']['habitat'].attribute?('plan_dir')
-    node['delivery']['config']['habitat']['plan_dir']
-  else
-    '/src/habitat'
+
+module HabitatBuildCookbook
+  module Helpers
+    #
+    # Get the plan directory from the config, or fallback to /src, set
+    # this in .delivery/config.json.
+    #
+    # Examples:
+    # {
+    #   ...
+    #   "habitat": {
+    #     "plan_dir": "/src/plans"
+    #     "plan_dir": "/elsewhere/plans/myplan"
+    #   }
+    # }
+    def habitat_plan_dir
+      if node['delivery']['config'].attribute?('habitat') &&
+         node['delivery']['config']['habitat'].attribute?('plan_dir')
+        node['delivery']['config']['habitat']['plan_dir']
+      else
+        '/src/habitat'
+      end
+    end
+
+    def habitat_origin_key?
+      project_secrets_exist?(%w(keyname private_key public_key))
+    end
+
+    def habitat_depot_token?
+      project_secrets_exist?(%w(depot_token))
+    end
+
+    def hab_binary
+      if platform_family?('mac_os_x')
+        '/usr/local/bin/hab'
+      else
+        '/bin/hab'
+      end
+    end
+
+    # For example, if the project is `surprise-sandwich`, and we're in the
+    # Build stage's Publish phase, the slug will be:
+    #
+    #    `surprise-sandwich-build-publish`
+    #
+    def hab_studio_slug
+      [
+        node['delivery']['change']['project'],
+        node['delivery']['change']['stage'],
+        node['delivery']['change']['phase'],
+      ].join('-')
+    end
+
+    def hab_studio_path
+      File.join('/hab/studios', hab_studio_slug)
+    end
+
+    def changed_habitat_files?
+      # `changed_files` comes from the delivery-sugar DSL: https://git.io/vXvAm
+      changed_files.select { |changed_file| changed_file =~ %r{habitat/} }.any?
+    end
+
+    private
+
+    # if we're going to load secrets, we need to make sure we actually
+    # have the data!
+    def project_secrets_exist?(secret_keys = [])
+      load_delivery_chef_config
+
+      begin
+        key_data = get_project_secrets.to_hash
+      rescue Net::HTTPServerException
+        return false
+      end
+
+      return false unless key_data.key?('habitat') && !key_data['habitat'].empty?
+
+      secret_keys.each do |req_key|
+        next if key_data['habitat'].key?(req_key) && !key_data['habitat'][req_key].empty?
+        return false
+      end
+
+      true
+    end
+
+    def last_build_env
+      Hash[*::File.read(::File.join(hab_studio_path, 'src/results/last_build.env')).split(/[=\n]/)]
+    end
+
+    def artifact
+      last_build_env['pkg_artifact']
+    end
+
+    def build_version
+      [last_build_env['pkg_version'], last_build_env['pkg_release']].join('/')
+    end
   end
 end
 
-def habitat_origin_key?
-  project_secrets_exist?(%w(keyname private_key public_key))
-end
-
-def habitat_depot_token?
-  project_secrets_exist?(%w(depot_token))
-end
-
-def hab_binary
-  if platform_family?('mac_os_x')
-    '/usr/local/bin/hab'
-  else
-    '/bin/hab'
-  end
-end
-
-# For example, if the project is `surprise-sandwich`, and we're in the
-# Build stage's Publish phase, the slug will be:
-#
-#    `surprise-sandwich-build-publish`
-#
-def hab_studio_slug
-  [
-    node['delivery']['change']['project'],
-    node['delivery']['change']['stage'],
-    node['delivery']['change']['phase'],
-  ].join('-')
-end
-
-def hab_studio_path
-  File.join('/hab/studios', hab_studio_slug)
-end
-
-def changed_habitat_files?
-  # `changed_files` comes from the delivery-sugar DSL: https://git.io/vXvAm
-  changed_files.select { |changed_file| changed_file =~ %r{habitat/} }.any?
-end
-
-private
-
-# if we're going to load secrets, we need to make sure we actually
-# have the data!
-def project_secrets_exist?(secret_keys = [])
-  load_delivery_chef_config
-
-  begin
-    key_data = get_project_secrets.to_hash
-  rescue Net::HTTPServerException
-    return false
-  end
-
-  return false unless key_data.key?('habitat') && !key_data['habitat'].empty?
-
-  secret_keys.each do |req_key|
-    next if key_data['habitat'].key?(req_key) && !key_data['habitat'][req_key].empty?
-    return false
-  end
-
-  true
-end
-
-def last_build_env
-  Hash[*::File.read(::File.join(hab_studio_path, 'src/results/last_build.env')).split(/[=\n]/)]
-end
-
-def artifact
-  last_build_env['pkg_artifact']
-end
-
-def build_version
-  [last_build_env['pkg_version'], last_build_env['pkg_release']].join('/')
-end
+Chef::Recipe.send(:include, HabitatBuildCookbook::Helpers)

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.10.8'
+version '0.10.9'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -17,25 +17,6 @@ property :live_stream, [TrueClass, FalseClass], default: true
 
 action_class do
   include HabitatBuildCookbook::Helpers
-
-  def data_bag_item_id
-    build_version.tr('/', '-')
-  end
-
-  # The current acceptance environment on the server
-  def existing_acceptance_environment
-    Chef::ServerAPI.new.get("environments/#{get_acceptance_environment}")
-  rescue Net::HTTPServerException => e
-    raise e unless e.response.code.to_i == 404
-    {}
-  end
-
-  def updated_environment_overrides
-    existing_overrides = existing_acceptance_environment.fetch('override_attributes', {})
-    existing_overrides['applications'] ||= {}
-    existing_overrides['applications'][new_resource.name] = build_version
-    existing_overrides
-  end
 end
 
 action :build do
@@ -43,9 +24,11 @@ action :build do
     command "sudo -E #{hab_binary} studio" \
             " -r #{hab_studio_path}" \
             " build #{plan_dir}"
-    environment('TERM' => 'vt100',
-                'HAB_ORIGIN' => origin,
-                'HAB_NONINTERACTIVE' => 'true')
+    environment(
+      'TERM' => 'vt100',
+      'HAB_ORIGIN' => origin,
+      'HAB_NONINTERACTIVE' => 'true'
+    )
     cwd new_resource.cwd
     live_stream new_resource.live_stream
   end
@@ -54,38 +37,25 @@ end
 action :publish do
   execute 'upload-pkg' do
     command lazy { "#{hab_binary} pkg upload --url #{url} #{hab_studio_path}/src/results/#{artifact}" }
-    env('HOME' => home_dir,
-        'HAB_AUTH_TOKEN' => auth_token,
-        'HAB_NONINTERACTIVE' => 'true')
+    env(
+      'HOME' => home_dir,
+      'HAB_AUTH_TOKEN' => auth_token,
+      'HAB_NONINTERACTIVE' => 'true'
+    )
     live_stream new_resource.live_stream
     sensitive true
   end
 
-  load_delivery_chef_config
-  chef_data_bag new_resource.name
-
-  # We need to be clear here to ensure that the magic done by cheffish
-  # doesn't cause any unexpected data bag item naming or contents.
-  # Thus, we have a unique project name for the resource, which does
-  # not get used because we're setting the `id` and the `data_bag`
-  # properties. We need to use `lazy {}` on the `id` and `raw_data`
-  # because those contain calculated values from a previously
-  # converged resource, `hab_build`, above.
-  #
-  chef_data_bag_item "store-#{new_resource.name}-artifact-data" do
-    id lazy { data_bag_item_id }
-    data_bag new_resource.name
-    raw_data lazy {
-      { 'id' => data_bag_item_id,
-        'version' => build_version,
+  ruby_block "create Habitat project release: #{new_resource.name} #{build_version}" do
+    block do
+      # This helper is part of the Delivery Sugar DSL...it's also an alias
+      # for `define_project_application`.
+      create_workflow_application_release(
+        new_resource.name,
+        build_version,
         'artifact' => last_build_env.merge('type' => 'hart'),
-        'delivery_data' => node['delivery'] }
-    }
-  end
-
-  chef_environment get_acceptance_environment do
-    override_attributes lazy {
-      updated_environment_overrides
-    }
+        'delivery_data' => node['delivery']
+      )
+    end
   end
 end

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -16,6 +16,8 @@ property :auth_token, String
 property :live_stream, [TrueClass, FalseClass], default: true
 
 action_class do
+  include HabitatBuildCookbook::Helpers
+
   def data_bag_item_id
     build_version.tr('/', '-')
   end

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -16,6 +16,10 @@ property :auth_token, String
 property :live_stream, [TrueClass, FalseClass], default: true
 
 action_class do
+  def data_bag_item_id
+    build_version.tr('/', '-')
+  end
+
   # The current acceptance environment on the server
   def existing_acceptance_environment
     Chef::ServerAPI.new.get("environments/#{get_acceptance_environment}")
@@ -67,10 +71,10 @@ action :publish do
   # converged resource, `hab_build`, above.
   #
   chef_data_bag_item "store-#{new_resource.name}-artifact-data" do
-    id lazy { build_version }
+    id lazy { data_bag_item_id }
     data_bag new_resource.name
     raw_data lazy {
-      { 'id' => build_version,
+      { 'id' => data_bag_item_id,
         'version' => build_version,
         'artifact' => last_build_env.merge('type' => 'hart'),
         'delivery_data' => node['delivery'] }


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

In order for Delivery Truck to handle Chef environment promotions
correctly an application's version data must be placed in a top-level
hash named `applications`.

More details on the _Project Applications_ pattern at:
https://docs.chef.io/delivery_truck.html#project-applications

Signed-off-by: Seth Chisamore <schisamo@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/655ed365-6774-4051-9da9-0dcf0c23d7fd