### PR TITLE
Add delivery local config

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Cookbook recipe helper methods.
 
 `habitat_depot_token?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `depot_token`.
 
+## Local Development
+
+If you have [ChefDK](https://downloads.chef.io/chefdk) installed you can run
+the unit, lint, and syntax checks against this cookbook locally with `delivery
+local verify`.
+
 ## License and Author
 
 - Author: Joshua Timberman <joshua@chef.io>

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.10.9'
+version '0.10.10'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -28,7 +28,7 @@ if changed_habitat_files?
   end
 
   # Only build and publish if we have a depot token
-  if habitat_depot_token?
+  if habitat_depot_token? # ~FC023
     hab_build node['delivery']['change']['project'] do
       origin origin
       plan_dir habitat_plan_dir

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.color = true               # Use color in STDOUT
+  config.formatter = :documentation # Use the specified formatter
+  config.log_level = :error         # Avoid deprecation notice SPAM
+end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Nathan Smith

Makes it so `delivery local verify` runs the standard stuff. Also makes
it all pass.

Signed-off-by: Nathan L Smith <smith@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/7014d70f-5a37-439d-ada6-55aa077c1757