### PR TITLE
Add retries and environment to `hab_build` resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.10.10'
+version '0.11.0'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Nathan Smith

Signed-off-by: Nathan L Smith <smith@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/f36462e5-911e-4377-8a6a-c862952cd3dd