### PR TITLE
Add a spec to make sure `environment` works on `hab_build`

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.11.1'
+version '0.11.2'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/spec/unit/resources/hab_build_spec.rb
+++ b/spec/unit/resources/hab_build_spec.rb
@@ -30,7 +30,9 @@ EOF
 
     it 'builds the package with hab studio' do
       expect(chef_run).to run_execute('build-plan').with(
-        command: 'sudo -E /bin/hab studio -r /hab/studios/testproject-teststage-testphase build /src/pandas'
+        command: 'sudo -E /bin/hab studio -r /hab/studios/testproject-teststage-testphase build /src/pandas',
+        environment: hash_including('ABC' => 'XYZ',
+                                    'HAB_NONINTERACTIVE' => 'true')
       )
     end
 

--- a/test/fixtures/cookbooks/test/recipes/publish.rb
+++ b/test/fixtures/cookbooks/test/recipes/publish.rb
@@ -17,6 +17,7 @@ execute 'hab origin key generate testorigin'
 hab_build 'testbuild' do
   action [:build, :publish]
   cwd '/plans'
+  environment('ABC' => 'XYZ')
   origin 'testorigin'
   plan_dir '/src/pandas'
   auth_token 'abcdef'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Nathan Smith

Wrote this just to make sure it's working. It is.

Signed-off-by: Nathan L Smith <smith@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/72d33b15-3303-4b0b-bed4-ca2be48a172a