### PR TITLE
Inject environment variables into studio when building

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.11.2'
+version '0.11.3'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/spec/unit/resources/hab_build_spec.rb
+++ b/spec/unit/resources/hab_build_spec.rb
@@ -30,7 +30,7 @@ EOF
 
     it 'builds the package with hab studio' do
       expect(chef_run).to run_execute('build-plan').with(
-        command: 'sudo -E /bin/hab studio -r /hab/studios/testproject-teststage-testphase build /src/pandas',
+        command: 'sudo -E /bin/hab studio -r /hab/studios/testproject-teststage-testphase run env TERM="vt100" HAB_ORIGIN="testorigin" HAB_NONINTERACTIVE="true" ABC="XYZ" build /src/pandas',
         environment: hash_including('ABC' => 'XYZ',
                                     'HAB_NONINTERACTIVE' => 'true')
       )


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Nathan Smith

Before you could have an `environment` property on a `hab_build`
resource but it wouldn't actually put the environment variables into the
studio when building.

This changes `hab studio build` to `hab studio run env MY=VARS build` so
that the variables are populated.

Signed-off-by: Nathan L Smith <smith@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/36677ac5-208d-43d0-b6ec-f016f6f89805