### PR TITLE
Remove delivery-truck publish to GitHub

### DIFF
--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -11,9 +11,6 @@
         "ignore_rules": ["FC016"],
         "excludes": ["spec", "test"]
       }
-    },
-    "publish": {
-      "github": "chef-cookbooks/habitat-build"
     }
   },
   "skip_phases": [],


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

We have enabled Automate's v2 Github integration for this cookbook's
pipeline which automatically handles pushing to the GitHub repo.

Signed-off-by: Seth Chisamore <schisamo@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/5006568a-2272-4ddd-87ad-072922aa4c59