### PR TITLE
rename url property to depot_url

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.13.0'
+version '0.13.1'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -35,7 +35,7 @@ if changed_habitat_files?
       cwd node['delivery']['workspace']['repo']
       home_dir delivery_workspace
       auth_token project_secrets['habitat']['depot_token']
-      url node['habitat-build']['depot-url']
+      depot_url node['habitat-build']['depot-url']
       action [:build, :publish, :save_application_release]
     end
   end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

In commit 1d769a9c, we renamed `url` to `depot_url` in the `hab_build`
resource, but not in the publish recipe.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/d136af05-7d0d-4a4b-8524-9235b220d915