### PR TITLE
Project release should use pkg_name from results

### DIFF
--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -36,6 +36,10 @@ action_class do
     [last_build_env['pkg_version'], last_build_env['pkg_release']].join('/')
   end
 
+  def package_name
+    last_build_env['pkg_name']
+  end
+
   def hab_studio_path
     ::File.join('/hab/studios', hab_studio_slug)
   end
@@ -94,13 +98,13 @@ action :publish do
 end
 
 action :save_application_release do
-  ruby_block "Create Automate project release for Habitat pakage: #{new_resource.name}" do
+  ruby_block 'create-automate-project-release' do
     block do
       Chef::Log.debug("Build version: #{build_version}")
       # This helper is part of the Delivery Sugar DSL...it's also an alias
       # for `define_project_application`.
       create_workflow_application_release(
-        new_resource.name,
+        package_name,
         build_version,
         'artifact' => last_build_env.merge('type' => 'hart'),
         'delivery_data' => node['delivery']

--- a/spec/unit/resources/hab_build_spec.rb
+++ b/spec/unit/resources/hab_build_spec.rb
@@ -110,7 +110,7 @@ describe 'test::save_application_release' do
 
     it 'saves the application release' do
       expect(chef_run).to save_application_release_hab_build('save_application_release')
-      expect(chef_run).to run_ruby_block('Create Automate project release for Habitat pakage: save_application_release')
+      expect(chef_run).to run_ruby_block('create-automate-project-release')
     end
   end
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

It is not guranteed that `hab_build` resource name will match the
underlying Habitat package name. To ensure the Automate project release
record is correct, we should pull the package name from the underlying
Habitat build results.

Signed-off-by: Seth Chisamore <schisamo@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/847e59e0-f4b7-4108-9508-c06a0f929396