### PR TITLE
Support multiple plan contexts

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,9 +2,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'delivery-truck'
-cookbook 'delivery-sugar', git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
-
 group :test do
   cookbook 'test', path: './test/fixtures/cookbooks/test'
 end

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ A build cookbook for running the parent project through Chef Automate.
 
 This build cookbook should be customized to suit the needs of the parent project. Do this by "wrapping" the cookbook as a dependency in your project's build cookbook.
 
+## Requirements
+
+Your project must have at least one of the following:
+  * a `habitat` directory that contains the `plan.sh` file and other files (as necessary) for your project to be packaged by Habitat
+  * a service directory that contains the `plan.sh` file (e.g. the format found in [habitat-sh/core-plans](https://github.com/habitat-sh/core-plans))
+
+## Setup
+
 Add to your build cookbook's metadata.rb:
 
 ```ruby
-depends 'delivery-sugar'
-depends 'delivery_build'
 depends 'habitat-build'
-depends 'delivery-truck'
 ```
 
 Add to your build cookbook's Berksfile:
@@ -20,8 +25,6 @@ source "https://supermarket.chef.io"
 
 metadata
 
-cookbook 'delivery-truck'
-cookbook 'delivery-sugar', git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
 cookbook 'habitat-build',  git: 'https://github.com/chef-cookbooks/habitat-build.git'
 ```
 
@@ -31,7 +34,27 @@ Include `habitat-build` recipes in your build cookbook's phase recipes. For exam
 include_recipe 'habitat-build::lint'
 ```
 
-Your project must have a `./habitat` directory that contains the `plan.sh` file and other files as necessary for your project to be packaged by Habitat - for example `default.toml`, or the run script.
+## Usage Patterns
+
+### My entire project is dedicated to a single Habitat package
+
+This is the recommended pattern when using this build cookbook. If you use this pattern, no additional steps are required! Simply include the appropriate `habitat-build` recipes in your build cookbook's phase recipes and carry on! For example in your build cookbook's `lint` recipe:
+
+```ruby
+include_recipe 'habitat-build::lint'
+```
+
+### My project has multiple standalone Habitat contexts inside it
+
+This pattern would apply if your project repo contains multiple Habitat plans, but a change to one plan does not necessitate that you rebuild another. An example of this would be the [habitat-sh/core-plans](https://github.com/habitat-sh/core-plans). If you are using this pattern, no additional steps are required! Simply include the appropriate `habitat-build` recipes in your build cookbook's phase recipes and carry on! For example in your build cookbook's `publish` recipe:
+
+```ruby
+include_recipe 'habitat-build::publish'
+```
+
+### My project has multiple interdependent Habitat contexts inside it
+
+This pattern would apply if your project repo contains multiple Habitat plans, some of which have inter-dependencies that require that when one is rebuilt so must another, or the execution of the Habitat builds must occur in a specific order. This is a pattern you might find yourself in if you're working with an application that is a monolith. In this case, you can still use the `default`, `lint`, and `syntax` recipes as is but you'll need to use the helpers outlined below to custom build your own `publish` and `provision` recipes. If this is your current scenario, we encourage you to familiarize yourself with the recipes and helpers in this cookbook and leverage them in the way that best suites your needs.
 
 ## Attributes
 
@@ -90,19 +113,13 @@ Does nothing in this cookbook.
 
 ## Libraries
 
-### client
-
-The `habitat-client` Ruby library. This is in the cookbook because we cannot publish it as a RubyGem until we release Habitat to the world. See rdoc comments in `libraries/client.rb` for more information.
-
-### exceptions
-
-Custom exception handlers for `habitat-client`.
-
 ### helpers
 
 Cookbook recipe helper methods.
 
-`habitat_plan_dir`: returns the directory where the plan lives. Searches the `delivery/config.json` of the build cookbook configuration, followed by an attribute, and falls back to `/src/habitat`.
+`habitat_plan_contexts`: returns a list of Habitat plan contexts in your project repository. If you specify a list of directories in your `.delivery/config.json` file under the `habitat['plan_dir']` key, it will return the list of corresponding plan contexts. Otherwise, it searches the project for Habitat plan files and returns an array of Habitat plan contexts that it can find (as determined by the presence of a `plan.sh` file). See the comment in the `helpers.rb` library for more information.
+
+`modified_habitat_plan_contexts`: returns a list of `habitat_plan_contexts` that were modified in the current change set.
 
 `habitat_origin_key?`: predicate method that returns `true` if there's a data bag item for the project's secrets in Chef Delivery, and if it has non-empty origin secrets in a hash key `habitat`, `keyname`, `private_key`, `public_key`.
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -15,27 +15,150 @@
 # limitations under the License.
 #
 
+#
+# plan_dir vs plan_context
+#   plan_dir: The directory where the plan.sh file is located.
+#   plan_context: The directory where either the 'habitat' folder or plan.sh file is located.
+#
+# The reason we make this distinction in this helper is primarily for the purpose
+# of detecting modified "services". Let's say you have a structure like this:
+#
+# . (root directory)
+# ├── bin
+# |   ├── (files ...)
+# ├── habitat
+# |   ├── plan.sh
+# ├── lib
+# |   ├── (files...)
+#
+# For a user of this cookbook, they'll likely want to trigger a build if a file
+# in `bin` or `lib` changes. In order to facilitate that, we need to consider the
+# larger "plan_context" (all the files in the root directory) and not just the
+# "plan_dir" (just the habitat folder with the plan.sh). This cookbook
+# differentiates these two concepts by using the terms plan_dir vs plan_context.
+#
+# From a Habitat perspective, the build command can take either the plan_dir or
+# the plan_context, so which one we use is of lttle consequence.
+#
 module HabitatBuildCookbook
   module Helpers
     #
-    # Get the plan directory from the config, or fallback to /src, set
-    # this in .delivery/config.json.
+    # Inspects your .delivery/config.json for the habitat['plan_dir'] value. This
+    # value can either be a string or an array of strings. Each string should be
+    # the directory where your plan.sh file is located.
     #
-    # Examples:
+    # Example #1: If your plan.sh is located in /src/plan-a/habitat/plan.sh
     # {
     #   ...
     #   "habitat": {
-    #     "plan_dir": "/src/plans"
-    #     "plan_dir": "/elsewhere/plans/myplan"
+    #     "plan_dir": "/src/plan-a/habitat"
     #   }
+    # }
+    #
+    # Example #2: Single plan directory elsewhere in in your studio, specified as an array
+    # {
+    #   ...
+    #   "habitat": {
+    #      "plan_dir": [
+    #        "/elsewhere/plans/myplan"
+    #      ]
+    #   }
+    # }
+    #
+    # Example #3: List of plans that will be built (in order)
+    # This is very useful if you only want to build a subset of plans, or build
+    # them in a specific order.
+    # {
+    #   ...
+    #   "habitat": [
+    #     "/src/myplans/plan-a/habitat",
+    #     "/src/myplans/plan-b/habitat",
+    #     "/elsewhere/plans/myplan"
+    #   ]
     # }
     def habitat_plan_dir
       if node['delivery']['config'].attribute?('habitat') &&
          node['delivery']['config']['habitat'].attribute?('plan_dir')
-        node['delivery']['config']['habitat']['plan_dir']
-      else
-        '/src/habitat'
+        [node['delivery']['config']['habitat']['plan_dir']].flatten
       end
+    end
+
+    #
+    # Returns all the Habitat **plan_contexts** in the current repository as an array.
+    #
+    # If one or more plan contexts were specified via the plan_dir value in the
+    # .delivery/config.json, use that list and return the associated plan_contexts.
+    # Otherwise, search the repository for Habitat plan contexts.
+    #
+    # Example 1: habitat_plan_dir
+    #
+    # habitat_plan_dir
+    # => ["/src/myplans/plan-a/habitat", "/src/myplans/plan-b/habitat", "/elsewhere/plans/myplan"]
+    # habitat_plan_contexts
+    # => ["/src/myplans/plan-a", "/src/myplans/plan-b", "/elsewhere/plans/myplan"]
+    #
+    #
+    def habitat_plan_contexts
+      # Assume that someone specifying the plan directories knows that they want
+      # and defer to that list. Otherwise, search the repository for potential
+      # Habitat plan directories.
+      plan_contexts = habitat_plan_dir || detect_plan_dirs
+
+      # If the user did not specify any plan directories,
+      # Search the repository for any habitat PLAN_CONTEXTs
+      all_dirs = plan_contexts.map do |plan_file|
+        plan_context_path = Pathname(plan_file).each_filename.to_a
+        plan_context_path.pop if plan_context_path.last == 'habitat'
+        "/#{File.join(plan_context_path)}"
+      end
+
+      all_dirs.uniq
+    end
+
+    #
+    # search the workspace repo for any plan.sh files inside of habitat
+    # directories, and return an array of paths to the plan_context for each
+    # service. This will return an array sorted lexigraphically.
+    #
+    # Example:
+    # Let's assume you have multiple habitat PLAN_CONTEXTs in a single repository
+    #
+    # $ tree .
+    #   .
+    #   ├── service-one
+    #   |   ├── habitat
+    #   |   |   ├── plan.sh
+    #   ├── service-two
+    #   |   ├── habitat
+    #   |   |   ├── plan.sh
+    #   ├── habitat-plans
+    #   |   ├── nested-service
+    #   |   |   ├── plan.sh
+    #
+    # This helper will return the following array:
+    # => [
+    #     "/src/service-one/habitat",
+    #     "/src/service-two/habitat",
+    #     "/src/habitat-plans/nested-service"
+    #    ]
+    #
+    def detect_plan_dirs
+      Dir.glob(File.join(workflow_workspace_repo, '**/**/plan.sh')).map do |dir|
+        Pathname(dir.sub(workflow_workspace_repo, '/src')).dirname.to_s
+      end
+    end
+
+    #
+    # Return a list of fully-qualified paths to habitat PLAN_CONTEXTs that have
+    # been modified in the current change.
+    #
+    # `changed_dirs` comes from the delivery-sugar DSL, and will return a list of
+    # all the directories (down to the deepest child) that have been modified. We
+    # do a union with our list of plan_contexts to determine which Habitat packages
+    # need to be rebuilt.
+    #
+    def modified_habitat_plan_contexts
+      habitat_plan_contexts & changed_dirs.map { |changed_dir| Pathname("/src/#{changed_dir}").cleanpath.to_s }
     end
 
     def habitat_origin_key?
@@ -55,8 +178,7 @@ module HabitatBuildCookbook
     end
 
     def changed_habitat_files?
-      # `changed_files` comes from the delivery-sugar DSL: https://git.io/vXvAm
-      changed_files.select { |changed_file| changed_file =~ %r{habitat/} }.any?
+      modified_habitat_plan_contexts.any?
     end
 
     # if we're going to load secrets, we need to make sure we actually

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.13.2'
+version '0.14.0'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/spec/unit/libraries/plan_detection_spec.rb
+++ b/spec/unit/libraries/plan_detection_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+require_relative '../../../libraries/helpers'
+
+describe 'test::detect' do
+  let(:cli_node) do
+    {
+      'delivery_builder' => {
+        'build_user' => 'dbuild',
+      },
+      'delivery' => {
+        'workspace_path' => '/workspace',
+        'workspace' => {
+          'repo' => '/workspace/path/to/phase/repo',
+          'cache' => '/workspace/path/to/phase/cache',
+          'chef' => '/workspace/path/to/phase/chef',
+        },
+        'change' => {
+          'stage' => 'stage',
+          'enterprise' => 'ent',
+          'organization' => 'org',
+          'project' => 'proj',
+          'change_id' => 'id',
+          'pipeline' => 'pipe',
+          'patchset_branch' => 'branch',
+          'sha' => 'sha',
+        },
+      },
+    }
+  end
+
+  let(:changed_dirs) do
+    [
+      '.',
+      'test/fixtures/plans/plan-a',
+      'test/fixtures/plans/plan-b',
+    ]
+  end
+
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:changed_dirs).and_return(changed_dirs)
+  end
+
+  context 'when the user specifies a single plan context in config.json' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '7.2'
+      ) do |node|
+        node.normal['delivery'] = cli_node['delivery']
+        node.normal['delivery_builder'] = cli_node['delivery_builder']
+        node.default['delivery']['config']['habitat']['plan_dir'] = '/src/test/fixtures/plans/plan-a'
+      end.converge(described_recipe)
+    end
+
+    it 'builds that plan context' do
+      expect(chef_run).to build_hab_build('plan-a').with(
+        plan_dir: '/src/test/fixtures/plans/plan-a'
+      )
+    end
+  end
+
+  context 'when the user specifies multiple plan contexts in config.json' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '7.2'
+      ) do |node|
+        node.normal['delivery'] = cli_node['delivery']
+        node.normal['delivery_builder'] = cli_node['delivery_builder']
+        node.default['delivery']['config']['habitat']['plan_dir'] = [
+          '/src/test/fixtures/plans/plan-a',
+          '/src/test/fixtures/plans/plan-b/habitat',
+        ]
+      end.converge(described_recipe)
+    end
+
+    it 'builds those contexts in order' do
+      expect(chef_run).to build_hab_build('plan-a').with(
+        plan_dir: '/src/test/fixtures/plans/plan-a'
+      )
+      expect(chef_run).to build_hab_build('plan-b').with(
+        plan_dir: '/src/test/fixtures/plans/plan-b'
+      )
+    end
+  end
+
+  context 'when the user does not specify any plan contexts' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '7.2'
+      ) do |node|
+        node.normal['delivery'] = cli_node['delivery']
+        node.normal['delivery_builder'] = cli_node['delivery_builder']
+        node.default['delivery']['config'] = {}
+      end.converge(described_recipe)
+    end
+
+    before do
+      allow(Dir).to receive(:glob).with('/workspace/path/to/phase/repo/**/**/plan.sh').and_return(
+        [
+          '/workspace/path/to/phase/repo/habitat/plan.sh',
+          '/workspace/path/to/phase/repo/test/fixtures/plans/plan-a/plan.sh',
+          '/workspace/path/to/phase/repo/test/fixtures/plans/plan-b/habitat/plan.sh',
+          '/workspace/path/to/phase/repo/test/fixtures/plans/plan-c/plan.sh',
+        ]
+      )
+    end
+
+    it 'searches for contexts in the repo' do
+      # When building a hab pkg in root, we name it after the project
+      expect(chef_run).to build_hab_build('proj').with(
+        plan_dir: '/src'
+      )
+      expect(chef_run).to build_hab_build('plan-a').with(
+        plan_dir: '/src/test/fixtures/plans/plan-a'
+      )
+      expect(chef_run).to build_hab_build('plan-b').with(
+        plan_dir: '/src/test/fixtures/plans/plan-b'
+      )
+      # Plan C was not modified, so do not build it
+      expect(chef_run).not_to build_hab_build('plan-c').with(
+        plan_dir: '/src/test/fixtures/plans/plan-c'
+      )
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/detect.rb
+++ b/test/fixtures/cookbooks/test/recipes/detect.rb
@@ -1,0 +1,16 @@
+# This recipe is a subset of the code available in publish
+modified_habitat_plan_contexts.each do |plan_context|
+  # Inside the build context, the "root" is called '/src'. In that scenario,
+  # we want to use the project name as the package name
+  pkg_name = plan_context == '/src' ? node['delivery']['change']['project'] : Pathname(plan_context).basename.to_s
+
+  hab_build pkg_name do
+    origin 'testorigin'
+    plan_dir plan_context
+    cwd '/plans'
+    # ignore the failure because we won't have a valid auth token
+    auth_token 'abcdef'
+    ignore_failure true
+    action :build
+  end
+end

--- a/test/fixtures/plans/plan-a/plan.sh
+++ b/test/fixtures/plans/plan-a/plan.sh
@@ -1,7 +1,7 @@
 # This is an example plan that does nothing, just produces a Habitat Artifact
 # that can be used for testing purposes.
 pkg_origin=build-cookbook
-pkg_name=pandas
+pkg_name=plan-a
 pkg_version=0.0.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')

--- a/test/fixtures/plans/plan-b/habitat/plan.sh
+++ b/test/fixtures/plans/plan-b/habitat/plan.sh
@@ -1,7 +1,7 @@
 # This is an example plan that does nothing, just produces a Habitat Artifact
 # that can be used for testing purposes.
 pkg_origin=build-cookbook
-pkg_name=pandas
+pkg_name=plan-b
 pkg_version=0.0.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')

--- a/test/fixtures/plans/plan-c/plan.sh
+++ b/test/fixtures/plans/plan-c/plan.sh
@@ -1,7 +1,7 @@
 # This is an example plan that does nothing, just produces a Habitat Artifact
 # that can be used for testing purposes.
 pkg_origin=build-cookbook
-pkg_name=pandas
+pkg_name=plan-c
 pkg_version=0.0.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

* Adds `habitat_plan_contexts`
* Adds `modified_habitat_plan_contexts`

Signed-off-by: Tom Duffield <tom@chef.io>

Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/1b980344-89be-4305-a2dd-919f3083fa71