### PR TITLE
Reorder habitat build resource to cleanup the studio before we try running the build

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.14.1'
+version '0.14.2'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -13,7 +13,6 @@ property :artifact, String
 property :home_dir, String
 property :auth_token, String
 property :live_stream, [true, false], default: true
-property :cleanup, [true, false], default: false
 
 action_class do
   def artifact
@@ -63,6 +62,13 @@ action_class do
 end
 
 action :build do
+  # Delete studio before we before we run. Run in Hab doesn't do this for us
+  # but build does.
+  execute 'remove-studio' do
+    command "sudo -E #{hab_binary} studio -r #{hab_studio_path} rm"
+    live_stream new_resource.live_stream
+  end
+
   execute 'build-plan' do
     command "sudo -E #{hab_binary} studio" \
             " -r #{hab_studio_path}" \
@@ -71,12 +77,6 @@ action :build do
     cwd new_resource.cwd
     retries new_resource.retries
     live_stream new_resource.live_stream
-  end
-
-  execute 'remove-studio' do
-    command "sudo -E #{hab_binary} studio rm #{hab_studio_path}"
-    live_stream live_stream
-    only_if { cleanup }
   end
 end
 

--- a/test/fixtures/cookbooks/test/recipes/build.rb
+++ b/test/fixtures/cookbooks/test/recipes/build.rb
@@ -23,5 +23,4 @@ hab_build 'testbuild' do
   auth_token 'abcdef'
   # ignore the failure because we won't have a valid auth token
   ignore_failure true
-  cleanup node['cleanup']
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Elliott Davis

* removes cleanup property



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/9b04853d-af17-4acc-8327-0aacb7086912