### PR TITLE
Allow hab to install the correct studio

### DIFF
--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -14,6 +14,14 @@
     }
   },
   "skip_phases": [],
-  "build_nodes": {},
+  "job_dispatch": {
+  "version": "v2",
+  "filters": {
+    "default": {
+      "platform": ["ubuntu"],
+      "platform_version": ["16.04"]
+    }
+  }
+},
   "dependencies": []
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.14.3'
+version '0.14.4'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'
@@ -10,5 +10,5 @@ depends 'delivery-truck'
 # Until the resources go into core Chef, use the cookbook:
 depends 'habitat', '>= 0.1.0'
 
-issues_url 'https://github.com/habitat-sh/habitat-build-cookbook/issues'
-source_url 'https://github.com/habitat-sh/habitat-build-cookbook'
+issues_url 'https://github.com/chef-cookbooks/habitat-build/issues'
+source_url 'https://github.com/chef-cookbooks/habitat-build'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,9 +27,7 @@ hab_install 'latest-habitat' do
   action :upgrade
 end
 
-hab_package 'core/hab-studio' do
-  action :upgrade
-end
+# hab-studio package will be installed by `hab studio`
 
 # phases are run as the `dbuild` user, and we need to execute the
 # `hab` command as root because it requires privileged access


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

Signed-off-by: Tom Duffield <tom@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/551cca10-f01f-4902-abda-3b24b1fce1c5) in Chef Automate and click the Approve button.