### PR TITLE
Remove frivolous load_delivery_chef_config

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -190,8 +190,6 @@ module HabitatBuildCookbook
     # if we're going to load secrets, we need to make sure we actually
     # have the data!
     def project_secrets_exist?(secret_keys = [])
-      load_delivery_chef_config
-
       begin
         key_data = get_project_secrets.to_hash
       rescue Net::HTTPServerException

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.14.6'
+version '0.14.7'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

This is not needed as `DeliverySugar::DSL.get_project_secrets` already
loads the Automate instance's Chef Server config when needed.

Besides that, see chef-cookbooks/cia_infra#96 for details on why you should
never, never, never, never, never, never use `load_delivery_chef_config`!

Signed-off-by: Seth Chisamore <schisamo@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/a42449b8-e3da-43d9-bc6a-c8950b46bea0) in Chef Automate and click the Approve button.