### PR TITLE
The default API url should no longer include '/v1/depot'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # By default we use the public Habitat Depot
 #
 # TODO: (jtimberman) Configure this from a Delivery `config.json`.
-default['habitat-build']['depot-url'] = 'https://willem.habitat.sh/v1/depot'
+default['habitat-build']['depot-url'] = 'https://willem.habitat.sh'
 
 # An array of codes to ignore in shellcheck (lint checker). By default
 # we exclude:

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.14.8'
+version '0.14.9'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

Addresses the change introduced in https://github.com/habitat-sh/habitat/pull/3239

Signed-off-by: Tom Duffield <tom@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/Delivery-Build-Cookbooks/projects/habitat-build/changes/3413b01b-0b2d-4e5f-a4f7-e8f5dd99982f) in Chef Automate and click the Approve button.