### PR TITLE
Revert "The default API url should no longer include '/v1/depot'"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # By default we use the public Habitat Depot
 #
 # TODO: (jtimberman) Configure this from a Delivery `config.json`.
-default['habitat-build']['depot-url'] = 'https://willem.habitat.sh'
+default['habitat-build']['depot-url'] = 'https://willem.habitat.sh/v1/depot'
 
 # An array of codes to ignore in shellcheck (lint checker). By default
 # we exclude:

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
 license 'apache2'
-version '0.14.9'
+version '0.14.8'
 
 depends 'delivery-sugar'
 depends 'delivery-truck'


### PR DESCRIPTION
Reverts chef-cookbooks/habitat-build#44