### PR TITLE
Resolve deprecation / foodcritic warnings

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'habitat-build'
 maintainer 'The Habitat Maintainers'
 maintainer_email 'humans@habitat.sh'
-license 'apache2'
+license 'Apache-2.0'
 version '0.14.9'
 
 depends 'delivery-sugar'

--- a/resources/hab_build.rb
+++ b/resources/hab_build.rb
@@ -2,14 +2,12 @@ require_relative '../libraries/helpers'
 
 resource_name :hab_build
 
-property :name, String, name_property: true
 property :origin, String, required: true
 property :plan_dir, String, required: true
 property :cwd, String, required: true
 property :depot_url, String
 property :channel, String
 property :environment, Hash, default: {}
-property :retries, Integer, default: 0
 property :artifact, String
 property :home_dir, String
 property :auth_token, String


### PR DESCRIPTION
Both name and retries are defined by Chef. We don't want to define these
again ourselves. Also fix the license to use the standard format.

Signed-off-by: Tim Smith <tsmith@chef.io>